### PR TITLE
Updated readme.rst to reflect correct filename

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Example
     MIDDLEWARE = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django_crowd_auth.middleware.sso',
+        'django_crowd_auth.middlewares.sso',
     ]
 
 


### PR DESCRIPTION
Ran into the issue described in https://github.com/pmuller/django-crowd-auth/issues/3 and realized the instructions in the readme gave middleware instead of middlewares as the filename.