### PR TITLE
Update to readme.rst to reflect correct filename

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Example
     MIDDLEWARE = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django_crowd_auth.middleware.sso',
+        'django_crowd_auth.middlewares.sso',
     ]
 
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Usage
 * To authenticate users against Crowd,
   add ``django_crowd_auth.backends.Backend`` to ``AUTHENTICATION_BACKENDS``.
 * To enable single-sign-on,
-  add ``django_crowd_auth.middleware.sso`` to ``MIDDLEWARE``.
+  add ``django_crowd_auth.middlewares.sso`` to ``MIDDLEWARE``.
   Ensure you also have
   ``django.contrib.sessions.middleware.SessionMiddleware`` and
   ``django.contrib.auth.middleware.AuthenticationMiddleware`` placed before it.


### PR DESCRIPTION
Ran into the issue described in #3 and realized the instructions in the readme gave middleware instead of middlewares as the filename.